### PR TITLE
Improve convertToDocx task

### DIFF
--- a/folge-3/build.gradle
+++ b/folge-3/build.gradle
@@ -1,4 +1,5 @@
 import org.asciidoctor.gradle.AsciidoctorTask
+import java.nio.file.Paths
 
 plugins {
   id "org.asciidoctor.convert" version "1.5.6"
@@ -69,9 +70,11 @@ task convertToDocx (
         dependsOn: 'generateDocBook',
         type: Exec
 ) {
-  workingDir 'build/asciidoc/docbook'
+  doFirst {
+    file(Paths.get(generateDocBook.outputDir.toString(), "docx")).mkdirs()
+  }
+  workingDir file(Paths.get(generateDocBook.outputDir.toString(), "docbook"))
   executable = "pandoc"
-  new File('build/asciidoc/docx/').mkdirs()
   args = ['-r','docbook',
           '-t','docx',
           '-o','../docx/master.docx',


### PR DESCRIPTION
* Use doFirst to make sure directory is created
* Refer to generateDocBook for the output dir to avoid path duplication